### PR TITLE
DDS-2908 Update dds-tokens Peer Dependency to Support v1.x

### DIFF
--- a/.changeset/famous-days-own.md
+++ b/.changeset/famous-days-own.md
@@ -1,0 +1,5 @@
+---
+"@daikin-oss/tailwind": minor
+---
+
+Update peer dependency constraint for `@daikin-oss/dds-tokens` to support version 1.x and above. The upper bound restriction has been removed to allow compatibility with the latest major version of dds-tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@arethetypeswrong/cli": "^0.17.1",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.11",
-        "@daikin-oss/dds-tokens": "^0.3.1",
+        "@daikin-oss/dds-tokens": "^1.1.0",
         "@eslint/js": "^9.17.0",
         "@tokens-studio/types": "^0.5.1",
         "@types/eslint-config-prettier": "^6.11.3",
@@ -32,7 +32,7 @@
         "typescript-eslint": "^8.18.1"
       },
       "peerDependencies": {
-        "@daikin-oss/dds-tokens": ">=0.2.1 <1.0.0",
+        "@daikin-oss/dds-tokens": ">=0.2.1",
         "tailwindcss": "^3.0.0 || ^4.0.0"
       }
     },
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@daikin-oss/dds-tokens": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@daikin-oss/dds-tokens/-/dds-tokens-0.3.1.tgz",
-      "integrity": "sha512-hYOD/AMJmJzS+t4cIgDvjTTnsj6SF2WICzrKK4ByzfzoyUDr7cZLyYiwfjlnm7WQISws0Sq9J/T/kyr7rnxRAg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@daikin-oss/dds-tokens/-/dds-tokens-1.1.0.tgz",
+      "integrity": "sha512-FD7ghGT0ZATfaY47VX/k4GjUdUmJsRBkQc0R/ALWE2wJgIQFS95GrE4vt329VK+2PrrIKcSfZWlGbVggxGYdFQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1690,6 +1690,7 @@
       "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.1",
         "@typescript-eslint/types": "8.18.1",
@@ -1873,6 +1874,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2605,6 +2607,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2667,6 +2670,7 @@
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3589,6 +3593,7 @@
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4027,6 +4032,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4700,6 +4706,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -4846,6 +4853,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5793,6 +5801,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6017,6 +6026,7 @@
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@arethetypeswrong/cli": "^0.17.1",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.11",
-    "@daikin-oss/dds-tokens": "^0.3.1",
+    "@daikin-oss/dds-tokens": "^1.1.0",
     "@eslint/js": "^9.17.0",
     "@tokens-studio/types": "^0.5.1",
     "@types/eslint-config-prettier": "^6.11.3",
@@ -72,7 +72,7 @@
     "typescript-eslint": "^8.18.1"
   },
   "peerDependencies": {
-    "@daikin-oss/dds-tokens": ">=0.2.1 <1.0.0",
+    "@daikin-oss/dds-tokens": ">=0.2.1",
     "tailwindcss": "^3.0.0 || ^4.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
This PR updates the peer dependency constraint for @daikin-oss/dds-tokens to support version 1.x and above.

## Changes
- Updated devDependency @daikin-oss/dds-tokens from ^0.3.1 to ^1.1.0
- Removed upper bound restriction (<1.0.0) from peerDependency to allow compatibility with dds-tokens v1.x

Fixes: DDS-2908